### PR TITLE
Small change in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ To build documentation locally, you could use the following commands:
 
    # Create a Python virtual environment and install requirements into it.
    virtualenv env --python=python3
-   . env/activate
+   . env/bin/activate
    pip install -r requirements.txt
 
    # Build the documentation


### PR DESCRIPTION
Changed `. env/activate` with `. env/bin/activate` in the instructions on how to build the documentation.


Signed-off-by: restelli <arestell@umd.edu>